### PR TITLE
Add panic handler param to graphql

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -30,6 +30,8 @@ type Params struct {
 	// Context may be provided to pass application-specific per-request
 	// information to resolve functions.
 	Context context.Context
+
+	PanicHandler func(err error)
 }
 
 func Do(p Params) *Result {
@@ -58,5 +60,6 @@ func Do(p Params) *Result {
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
 		Context:       p.Context,
+		PanicHandler:  p.PanicHandler,
 	})
 }


### PR DESCRIPTION
Lets you get the error thrown in a resolve handler to, for instance, forward
to your exception logging system

cc @tberman 